### PR TITLE
Updata JSON input for HallThruster.jl

### DIFF
--- a/src/hallmd/juliapkg.json
+++ b/src/hallmd/juliapkg.json
@@ -4,7 +4,7 @@
 		"HallThruster": {
 			"uuid": "2311f341-5e6d-4941-9e3e-3ce0ae0d9ed6",
 			"url": "https://github.com/UM-PEPL/HallThruster.jl",
-			"version": "0.14.0"
+			"version": "0.14.1"
 		}
 	}
 }

--- a/src/hallmd/juliapkg.json
+++ b/src/hallmd/juliapkg.json
@@ -1,10 +1,10 @@
 {
-	"julia": "1.9",
+	"julia": "1.10",
 	"packages": {
 		"HallThruster": {
 			"uuid": "2311f341-5e6d-4941-9e3e-3ce0ae0d9ed6",
 			"url": "https://github.com/UM-PEPL/HallThruster.jl",
-			"version": "0.12.0"
+			"version": "0.14.0"
 		}
 	}
 }

--- a/src/hallmd/juliapkg.json
+++ b/src/hallmd/juliapkg.json
@@ -4,7 +4,8 @@
 		"HallThruster": {
 			"uuid": "2311f341-5e6d-4941-9e3e-3ce0ae0d9ed6",
 			"url": "https://github.com/UM-PEPL/HallThruster.jl",
-			"version": "0.14.1"
+			"rev": "7e5388939e03952ccea9694c4e9222f776cafe93",
+			"version": "0.14.2"
 		}
 	}
 }

--- a/src/hallmd/models/config/hallthruster_jl.json
+++ b/src/hallmd/models/config/hallthruster_jl.json
@@ -25,7 +25,7 @@
         "anom_model": "TwoZoneBohm",
         "neutral_temp_K": 300,
         "ion_temp_K": 1000,
-        "background_temperature_K": 300
+        "background_temperature_K": 300,
         "apply_thrust_divergence_correction": false
     }
 }

--- a/src/hallmd/models/config/hallthruster_jl.json
+++ b/src/hallmd/models/config/hallthruster_jl.json
@@ -27,5 +27,6 @@
         "neutral_temp_K": 300,
         "ion_temp_K": 1000,
         "background_temperature_K": 300
+        "apply_thrust_divergence_correction": false
     }
 }

--- a/src/hallmd/models/config/hallthruster_jl.json
+++ b/src/hallmd/models/config/hallthruster_jl.json
@@ -23,7 +23,6 @@
         "ion_wall_losses": true,
         "electron_ion_collisions": true,
         "anom_model": "TwoZoneBohm",
-        "solve_background_neutrals": true,
         "neutral_temp_K": 300,
         "ion_temp_K": 1000,
         "background_temperature_K": 300

--- a/src/hallmd/models/config/hallthruster_jl.json
+++ b/src/hallmd/models/config/hallthruster_jl.json
@@ -1,6 +1,6 @@
 {
-    "all_inputs": ["PB", "Va", "mdot_a", "T_ec", "u_n", "c_w", "l_t", "vAN1", "vAN2", "delta_z", "z0", "p0", "alpha", "l_c", "V_cc"],
-    "inputs": ["PB", "Va", "mdot_a", "T_ec", "u_n", "l_t", "vAN1", "vAN2", "delta_z", "z0", "p0", "V_cc"],
+    "default_inputs": ["PB", "Va", "mdot_a", "T_ec", "u_n", "c_w", "l_t", "f_n", "vAN1", "vAN2", "vAN3", "vAN4", "delta_z", "z0", "p0", "alpha", "l_c", "V_cc"],
+    "required_inputs": ["PB", "Va", "mdot_a", "T_ec", "u_n", "l_t", "vAN1", "vAN2", "delta_z", "z0", "p0", "V_cc"],
     "outputs": ["I_B0", "I_D", "T", "eta_v", "eta_c", "eta_m", "ui_avg", "uion"],
     "SPT-100": {
         "channel_length": 0.025,

--- a/src/hallmd/models/config/variables_v0.json
+++ b/src/hallmd/models/config/variables_v0.json
@@ -76,16 +76,27 @@
         "rv_type": "uniform_bds",
         "rv_params": [100, 500]
     },
+    "f_n": {
+        "id": "f_n",
+        "tex": "$f_n$",
+        "description": "Neutral ingestion multiplier",
+        "units": "m/s",
+        "param_type": "calibration",
+        "nominal": 1.0,
+        "domain": [0.5, 10.0],
+        "rv_type": "uniform_bds",
+        "rv_params": [0.5, 10.0]
+    },
     "c_w": {
         "id": "c_w",
         "tex": "$c_w$",
         "description": "Wall sheath loss coefficient",
         "units": "-",
         "param_type": "calibration",
-        "nominal": 0.2,
-        "domain": [0.1, 0.3],
+        "nominal": 1.0,
+        "domain": [0.2, 2.0],
         "rv_type": "uniform_bds",
-        "rv_params": [0.1, 0.3]
+        "rv_params": [0.2, 2.0]
     },
     "l_t": {
         "id": "l_t",
@@ -119,6 +130,28 @@
         "domain": [10, 100],
         "rv_type": "uniform_bds",
         "rv_params": [10, 100]
+    },
+    "vAN3": {
+        "id": "vAN3",
+        "tex": "$a_3$",
+        "description": "Anomalous transport coefficient 3",
+        "units": "-",
+        "param_type": "calibration",
+        "nominal": 0.022,
+        "domain": [0.02, 0.035],
+        "rv_type": "uniform_bds",
+        "rv_params": [0.02, 0.035]
+    },
+    "vAN4": {
+        "id": "vAN4",
+        "tex": "$a_4$",
+        "description": "Anomalous transport coefficient 4",
+        "units": "-",
+        "param_type": "calibration",
+        "nominal": 0.01,
+        "domain": [0.001, 0.02],
+        "rv_type": "uniform_bds",
+        "rv_params": [0.001, 0.02]
     },
     "delta_z": {
         "id": "delta_z",

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -67,7 +67,7 @@ def hallthruster_jl_input(thruster_input: dict) -> dict:
         'anom_model_coeffs': anom_model_coeffs,
         'background_pressure_Torr': 10 ** thruster_input['PB'],
         'background_temperature_K': thruster_input['background_temperature_K'],
-        'neutral_ingestion_multiplier': thruster_input['neutral_ingestion_multiplier'],
+        'neutral_ingestion_multiplier': thruster_input['f_n'],
         'apply_thrust_divergence_correction': thruster_input['apply_thrust_divergence_correction'],
         # design
         'thruster_name': thruster_input['thruster_name'],

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -68,7 +68,7 @@ def hallthruster_jl_input(thruster_input: dict) -> dict:
         'background_pressure_Torr': 10 ** thruster_input['PB'],
         'background_temperature_K': thruster_input['background_temperature_K'],
         'neutral_ingestion_multiplier': thruster_input['neutral_ingestion_multiplier'],
-        'apply_thrust_divergence_correction': thruster_input['apply_thrust_divergence_correction']
+        'apply_thrust_divergence_correction': thruster_input['apply_thrust_divergence_correction'],
         # design
         'thruster_name': thruster_input['thruster_name'],
         'inner_radius': thruster_input['inner_radius'],

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -45,7 +45,7 @@ def hallthruster_jl_input(thruster_input: dict) -> dict:
 
     anom_model = thruster_input['anom_model']
     anom_model_coeffs = []
-    if (anom_model == "ShiftedTwoZoneBohm" || anom_model == "TwoZoneBohm"):
+    if (anom_model == "ShiftedTwoZoneBohm" or anom_model == "TwoZoneBohm"):
         vAN1 = 10 ** thruster_input['vAN1']
         vAN2 = vAN1 * thruster_input['vAN2']
         anom_model_coeffs = [vAN1, vAN2]

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -96,7 +96,7 @@ def hallthruster_jl_input(thruster_input: dict) -> dict:
         'anom_model': thruster_input['anom_model'],
     }
     
-    if anom_model 'ShiftedTwoZone' or anom_model == 'ShiftedGaussianBohm':
+    if anom_model == 'ShiftedTwoZone' or anom_model == 'ShiftedGaussianBohm':
         # Add extra parameters for anomalous transport models that depend on pressure
         json_data.update({'pressure_dz': thruster_input['delta_z'] * thruster_input['channel_length'],
                           'pressure_z0': thruster_input['z0'] * thruster_input['channel_length'],

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -42,16 +42,15 @@ def hallthruster_jl_input(thruster_input: dict) -> dict:
     :param thruster_input: dictionary with all named thruster inputs and values
     :returns: a nested `dict` in the format that Hallthruster.jl expects to be called
     """
-
     anom_model = thruster_input['anom_model']
     anom_model_coeffs = []
-    if (anom_model == "ShiftedTwoZoneBohm" or anom_model == "TwoZoneBohm"):
+    if anom_model == "ShiftedTwoZoneBohm" or anom_model == "TwoZoneBohm":
         vAN1 = 10 ** thruster_input['vAN1']
         vAN2 = vAN1 * thruster_input['vAN2']
         anom_model_coeffs = [vAN1, vAN2]
-    elif (anom_model == "ShiftedGaussianBohm"):
-        vAN1 = thruster_input['vAN1']
-        vAN2 = thruster_input['vAN2']
+    elif anom_model == "ShiftedGaussianBohm":
+        vAN1 = 10 ** thruster_input['vAN1']
+        vAN2 = vAN1 * thruster_input['vAN2']
         vAN3 = thruster_input['vAN3']
         vAN4 = thruster_input['vAN4']
         anom_model_coeffs = [vAN1, vAN2, vAN3, vAN4]
@@ -219,10 +218,10 @@ def hallthruster_jl_wrapper(x: np.ndarray, alpha: tuple = (2, 2), *, compress: b
     # Constant inputs from config file (thruster geometry, propellant, wall material, simulation params, etc.)
     with open(Path(config), 'r') as fd:
         config_data = json.load(fd)
-        default_inputs = load_variables(config_data['all_inputs'], Path(variables))
-        base_input = {var.id: var.nominal for var in default_inputs}  # Set default values for required inputs
+        default_inputs = load_variables(config_data['default_inputs'], Path(variables))
+        base_input = {var.id: var.nominal for var in default_inputs}  # Set default values for variables.json RV inputs
         base_input.update(config_data[thruster])                      # Set all other simulation configs
-        input_list = config_data['inputs']  # Needs to match xdim and correspond with str input ids to hallthruster.jl
+        input_list = config_data['required_inputs']  # Needs to match xdim and correspond with str input ids to hallthruster.jl
         output_list = config_data['outputs']
     base_input.update({'num_cells': Ncells, 'dt_s': dt_s, 'max_charge': Ncharge})  # Update model fidelity params
 

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -96,7 +96,7 @@ def hallthruster_jl_input(thruster_input: dict) -> dict:
         'anom_model': thruster_input['anom_model'],
     }
     
-    if thruster_input['anom_model'] == 'ShiftedTwoZone' || thruster_input['anom_model'] == 'ShiftedGaussianBohm':
+    if anom_model 'ShiftedTwoZone' or anom_model == 'ShiftedGaussianBohm':
         # Add extra parameters for anomalous transport models that depend on pressure
         json_data.update({'pressure_dz': thruster_input['delta_z'] * thruster_input['channel_length'],
                           'pressure_z0': thruster_input['z0'] * thruster_input['channel_length'],

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -49,7 +49,7 @@ def hallthruster_jl_input(thruster_input: dict) -> dict:
         vAN1 = 10 ** thruster_input['vAN1']
         vAN2 = vAN1 * thruster_input['vAN2']
         anom_model_coeffs = [vAN1, vAN2]
-    elif (anom_model == "ShiftedGaussianBohm")
+    elif (anom_model == "ShiftedGaussianBohm"):
         vAN1 = thruster_input['vAN1']
         vAN2 = thruster_input['vAN2']
         vAN3 = thruster_input['vAN3']

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,7 +21,7 @@ def test_example():
 
 
 def test_plume(plots=False):
-    variables = load_variables(["PB", "c0", "c1", "c2", "c3", "c4", "c5", "sigma_cex", "r_m", "I_B0", "f_n"],
+    variables = load_variables(["PB", "c0", "c1", "c2", "c3", "c4", "c5", "sigma_cex", "r_m", "I_B0"],
                                CONFIG_DIR / 'variables_v0.json')
     N = 100
     x = np.empty((N, len(variables)))
@@ -60,7 +60,7 @@ def test_cc(plots=False):
 
 def test_hallthruster_jl(plots=False):
     variables = load_variables(["PB", "Va", "mdot_a", "T_ec", "u_n", "l_t", "vAN1", "vAN2", "delta_z",
-                                "z0", "p0", "V_cc"], CONFIG_DIR / 'variables_v0.json')
+                                "z0", "p0", "V_cc", "f_n", CONFIG_DIR / 'variables_v0.json')
     x = np.empty((2, len(variables)))
     for i, var in enumerate(variables):
         x[:, i] = var.sample_domain(2)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -60,7 +60,7 @@ def test_cc(plots=False):
 
 def test_hallthruster_jl(plots=False):
     variables = load_variables(["PB", "Va", "mdot_a", "T_ec", "u_n", "l_t", "vAN1", "vAN2", "delta_z",
-                                "z0", "p0", "V_cc", "f_n", CONFIG_DIR / 'variables_v0.json')
+                                "z0", "p0", "V_cc", "f_n"], CONFIG_DIR / 'variables_v0.json')
     x = np.empty((2, len(variables)))
     for i, var in enumerate(variables):
         x[:, i] = var.sample_domain(2)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,7 +59,7 @@ def test_cc(plots=False):
 
 
 def test_hallthruster_jl(plots=False):
-    variables = load_variables(["PB", "Va", "mdot_a", "T_ec", "u_n", "l_t", "vAN1", "vAN2", "delta_z",
+    variables = load_variables(["PB", "Va", "mdot_a", "T_ec", "u_n", "l_t", "vAN1", "vAN2", "vAN3", "vAN4", "delta_z",
                                 "z0", "p0", "V_cc", "f_n"], CONFIG_DIR / 'variables_v0.json')
     x = np.empty((2, len(variables)))
     for i, var in enumerate(variables):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,7 +21,7 @@ def test_example():
 
 
 def test_plume(plots=False):
-    variables = load_variables(["PB", "c0", "c1", "c2", "c3", "c4", "c5", "sigma_cex", "r_m", "I_B0"],
+    variables = load_variables(["PB", "c0", "c1", "c2", "c3", "c4", "c5", "sigma_cex", "r_m", "I_B0", "f_n"],
                                CONFIG_DIR / 'variables_v0.json')
     N = 100
     x = np.empty((N, len(variables)))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,13 +59,14 @@ def test_cc(plots=False):
 
 
 def test_hallthruster_jl(plots=False):
-    variables = load_variables(["PB", "Va", "mdot_a", "T_ec", "u_n", "l_t", "vAN1", "vAN2", "vAN3", "vAN4", "delta_z",
-                                "z0", "p0", "V_cc", "f_n"], CONFIG_DIR / 'variables_v0.json')
+    """This test must coincide with the `required_inputs` of the config file passed to `hallthruster_jl_wrapper`"""
+    variables = load_variables(["PB", "Va", "mdot_a", "T_ec", "u_n", "l_t", "vAN1", "vAN2", "delta_z",
+                                "z0", "p0", "V_cc"], CONFIG_DIR / 'variables_v0.json')
     x = np.empty((2, len(variables)))
     for i, var in enumerate(variables):
         x[:, i] = var.sample_domain(2)
     alpha = (0, 0)
-    res = hallthruster_jl_wrapper(x, alpha, n_jobs=2)
+    res = hallthruster_jl_wrapper(x, alpha, n_jobs=2, config=CONFIG_DIR / 'hallthruster_jl.json')
 
     if plots:
         fig, ax = plt.subplots()


### PR DESCRIPTION
*Update

I've simplified HallThruster.jl's input JSON handling. It now uses a single section. I've also added a few new options:

## Additions
1. A `ShiftedGaussianBohm` model with four parameters
2. A switch `apply_thrust_divergence_correction` for turning on and off divergence modeling in HallThruster.jl
3. A `neutral_ingestion_multiplier` for increasing the amount of neutrals ingested in the thruster

I've also removed the `solve_background_neutrals` key, as that is no longer used in HallThruster.jl.

Lastly, I've bumped the Julia version to 1.10 and the HallThruster.jl version to 0.14. That version will be tagged shortly over on the HallThruster.jl repo.
