### PR TITLE
Fix some thruster parameter computations

### DIFF
--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -27,7 +27,7 @@ import string
 import juliacall
 import numpy as np
 from joblib import Parallel, delayed, cpu_count
-from joblib.externals.loky import set_loky_picklerx
+from joblib.externals.loky import set_loky_pickler
 from amisc.utils import load_variables, get_logger
 
 from hallmd.utils import ModelRunException, data_write, model_config_dir

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -126,7 +126,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
         json.dump(json_data, fd, ensure_ascii=False, indent=4)
         fd.close()
         t1 = time.time()
-        sol = jl.seval(r'sol = HallThruster.run_simulation("{}", verbose=false)'.format(fd.name))
+        sol = jl.seval(r'sol = HallThruster.run_simulation("{repr(fd.name)[1:-1]}", verbose=false)')
         os.unlink(fd.name)   # delete the tempfile
     except juliacall.JuliaError as e:
         raise ModelRunException(f"Julicall error in Hallthruster.jl: {e}")

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -135,7 +135,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
         raise ModelRunException(f"Exception in Hallthruster.jl: Retcode = {sol.retcode}")
 
     # Average simulation results
-    avg = jl.HallThruster.time_average(sol, thruster_input['time_avg_frame_start'])
+    avg = jl.seval(f"avg = HallThruster.time_average(sol, {thruster_input['time_avg_frame_start']}")
 
     # Extract needed data
     I_B0 = jl.HallThruster.ion_current(avg)[0]

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -143,7 +143,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
     ni_exit = 0.0
     for Z in range(avg.params.ncharge):
         ni_exit += jl.seval(f"avg[:ni, {Z}][][end]")
-        niui_exit += jl.seval(f"avg[:niui, Z][][end]")
+        niui_exit += jl.seval(f"avg[:niui, {Z}][][end]")
     end
     ui_avg = niui_exit / ni_exit
     
@@ -164,7 +164,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
                                'eta_v': thruster_output[0]['voltage_eff']})
 
     # Raise an exception if thrust or beam current are negative (non-physical cases)
-    if thrust < 0 or I_B0 < 0:
+    if thrust < 0 or I_B0 < 0:x
         raise ModelRunException(f'Exception due to non-physical case: thrust={thrust} N, beam current={I_B0} A')
 
     return thruster_output[0]

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -126,7 +126,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
         json.dump(json_data, fd, ensure_ascii=False, indent=4)
         fd.close()
         t1 = time.time()
-        sol = jl.seval(f'sol = HallThruster.run_simulation("{fd.name}", verbose=False)')
+        sol = jl.seval(f'sol = HallThruster.run_simulation("{fd.name}", verbose=false)')
         os.unlink(fd.name)   # delete the tempfile
     except juliacall.JuliaError as e:
         raise ModelRunException(f"Julicall error in Hallthruster.jl: {e}")

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -164,7 +164,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
                                'eta_v': thruster_output[0]['voltage_eff']})
 
     # Raise an exception if thrust or beam current are negative (non-physical cases)
-    if thrust < 0 or I_B0 < 0:x
+    if thrust < 0 or I_B0 < 0:
         raise ModelRunException(f'Exception due to non-physical case: thrust={thrust} N, beam current={I_B0} A')
 
     return thruster_output[0]

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -139,15 +139,14 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
 
     # Extract needed data
     I_B0 = jl.HallThruster.ion_current(avg)[0]
-    ui_avg = jl.seval("""
-        niui_exit = 0.0
+    ui_avg_code = """niui_exit = 0.0
         ni_exit = 0.0
         for Z in 1:avg.params.ncharge
             ni_exit += avg[:ni, Z][][end]
             niui_exit += avg[:niui, Z][][end]
         end
-        niui_exit / ni_exit
-    """)
+        niui_exit / ni_exit"""
+    ui_avg = jl.seval(ui_avg_code)
     
     # Load simulation results
     fd = tempfile.NamedTemporaryFile(suffix='.json', encoding='utf-8', mode='w', delete=False)

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -144,7 +144,6 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
     for Z in range(avg.params.ncharge):
         ni_exit += jl.seval(f"avg[:ni, {Z+1}][][end]")
         niui_exit += jl.seval(f"avg[:niui, {Z+1}][][end]")
-    end
     ui_avg = niui_exit / ni_exit
     
     # Load simulation results

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -139,12 +139,15 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
 
     # Extract needed data
     I_B0 = jl.HallThruster.ion_current(avg)[0]
-    niui_exit = 0
-    ni_exit = 0
-    for Z in avg.params.ncharge:
-        ni_exit += avg[:ni, Z][0][-1]
-        niui_exit += avg[:niui, Z][0][-1]
-    ui_avg = niui_exit / ni_exit
+    ui_avg = jl.seval("""
+        niui_exit = 0.0
+        ni_exit = 0.0
+        for Z in 1:avg.params.ncharge
+            ni_exit += avg[:ni, Z][][end]
+            niui_exit += avg[:niui, Z][][end]
+        end
+        niui_exit / ni_exit
+    """)
     
     # Load simulation results
     fd = tempfile.NamedTemporaryFile(suffix='.json', encoding='utf-8', mode='w', delete=False)

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -135,7 +135,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
         raise ModelRunException(f"Exception in Hallthruster.jl: Retcode = {sol.retcode}")
 
     # Average simulation results
-    avg = jl.seval(f"avg = HallThruster.time_average(sol, {thruster_input['time_avg_frame_start']}")
+    avg = jl.seval(f"avg = HallThruster.time_average(sol, {thruster_input['time_avg_frame_start']})")
 
     # Extract needed data
     I_B0 = jl.HallThruster.ion_current(avg)[0]

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -134,26 +134,27 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
     if str(sol.retcode).lower() != "success":
         raise ModelRunException(f"Exception in Hallthruster.jl: Retcode = {sol.retcode}")
 
+    # Average simulation results
+    avg = jl.HallThruster.time_average(sol, thruster_input['time_avg_frame_start'])
+
+    # Extract needed data
+    I_B0 = jl.HallThruster.ion_current(avg)[0]
+    niui_exit = 0
+    ni_exit = 0
+    for Z in avg.params.ncharge:
+        ni_exit += avg[:ni, Z][0][-1]
+        niui_exit += avg[:niui, Z][0][-1]
+    ui_avg = niui_exit / ni_exit
+    
     # Load simulation results
     fd = tempfile.NamedTemporaryFile(suffix='.json', encoding='utf-8', mode='w', delete=False)
     fd.close()
-    jl.HallThruster.write_to_json(fd.name, jl.HallThruster.time_average(sol, thruster_input['time_avg_frame_start']))
+    
+    jl.HallThruster.write_to_json(fd.name, ))
     with open(fd.name, 'r') as f:
         thruster_output = json.load(f)
     os.unlink(fd.name)  # delete the tempfile
 
-    j_exit = 0      # Current density at thruster exit
-    ui_exit = 0     # Ion velocity at thruster exit
-    for param, grid_sol in thruster_output[0].items():
-        if 'niui' in param:
-            charge_num = int(param.split('_')[1])
-            j_exit += Q_E * charge_num * grid_sol[-1]
-        if param.split('_')[0] == 'ui':
-            ui_exit += grid_sol[-1]
-
-    A = np.pi * (thruster_input['outer_radius'] ** 2 - thruster_input['inner_radius'] ** 2)
-    ui_avg = ui_exit / thruster_input['max_charge']
-    I_B0 = j_exit * A           # Total current (A) at thruster exit
     thrust = thruster_output[0]['thrust']
     discharge_current = thruster_output[0]['discharge_current']
 

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -126,7 +126,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
         json.dump(json_data, fd, ensure_ascii=False, indent=4)
         fd.close()
         t1 = time.time()
-        sol = jl.seval(f"sol = HallThruster.run_simulation({fd.name}, verbose=False)")
+        sol = jl.seval(f'sol = HallThruster.run_simulation("{fd.name}", verbose=False)')
         os.unlink(fd.name)   # delete the tempfile
     except juliacall.JuliaError as e:
         raise ModelRunException(f"Julicall error in Hallthruster.jl: {e}")

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -126,7 +126,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
         json.dump(json_data, fd, ensure_ascii=False, indent=4)
         fd.close()
         t1 = time.time()
-        sol = jl.seval(r'sol = HallThruster.run_simulation("{repr(fd.name)[1:-1]}", verbose=false)')
+        sol = jl.seval(f'sol = HallThruster.run_simulation("{repr(fd.name)[1:-1]}", verbose=false)')
         os.unlink(fd.name)   # delete the tempfile
     except juliacall.JuliaError as e:
         raise ModelRunException(f"Julicall error in Hallthruster.jl: {e}")

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -27,7 +27,7 @@ import string
 import juliacall
 import numpy as np
 from joblib import Parallel, delayed, cpu_count
-from joblib.externals.loky import set_loky_pickler
+from joblib.externals.loky import set_loky_picklerx
 from amisc.utils import load_variables, get_logger
 
 from hallmd.utils import ModelRunException, data_write, model_config_dir
@@ -150,7 +150,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
     fd = tempfile.NamedTemporaryFile(suffix='.json', encoding='utf-8', mode='w', delete=False)
     fd.close()
     
-    jl.HallThruster.write_to_json(fd.name, ))
+    jl.HallThruster.write_to_json(fd.name, avg)
     with open(fd.name, 'r') as f:
         thruster_output = json.load(f)
     os.unlink(fd.name)  # delete the tempfile

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -126,7 +126,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
         json.dump(json_data, fd, ensure_ascii=False, indent=4)
         fd.close()
         t1 = time.time()
-        sol = jl.seval(f'sol = HallThruster.run_simulation("{fd.name}", verbose=false)')
+        sol = jl.seval(r'sol = HallThruster.run_simulation("{}", verbose=false)'.format(fd.name))
         os.unlink(fd.name)   # delete the tempfile
     except juliacall.JuliaError as e:
         raise ModelRunException(f"Julicall error in Hallthruster.jl: {e}")

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -126,7 +126,7 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
         json.dump(json_data, fd, ensure_ascii=False, indent=4)
         fd.close()
         t1 = time.time()
-        sol = jl.HallThruster.run_simulation(fd.name, verbose=False)
+        sol = jl.seval(f"sol = HallThruster.run_simulation({fd.name}, verbose=False)")
         os.unlink(fd.name)   # delete the tempfile
     except juliacall.JuliaError as e:
         raise ModelRunException(f"Julicall error in Hallthruster.jl: {e}")

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -139,14 +139,13 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
 
     # Extract needed data
     I_B0 = jl.HallThruster.ion_current(avg)[0]
-    ui_avg_code = """niui_exit = 0.0
-        ni_exit = 0.0
-        for Z in 1:avg.params.ncharge
-            ni_exit += avg[:ni, Z][][end]
-            niui_exit += avg[:niui, Z][][end]
-        end
-        niui_exit / ni_exit"""
-    ui_avg = jl.seval(ui_avg_code)
+    niui_exit = 0.0
+    ni_exit = 0.0
+    for Z in range(avg.params.ncharge):
+        ni_exit += jl.seval(f"avg[:ni, {Z}][][end]")
+        niui_exit += jl.seval(f"avg[:niui, Z][][end]")
+    end
+    ui_avg = niui_exit / ni_exit
     
     # Load simulation results
     fd = tempfile.NamedTemporaryFile(suffix='.json', encoding='utf-8', mode='w', delete=False)

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -142,8 +142,8 @@ def hallthruster_jl_model(thruster_input: dict, jl=None) -> dict:
     niui_exit = 0.0
     ni_exit = 0.0
     for Z in range(avg.params.ncharge):
-        ni_exit += jl.seval(f"avg[:ni, {Z}][][end]")
-        niui_exit += jl.seval(f"avg[:niui, {Z}][][end]")
+        ni_exit += jl.seval(f"avg[:ni, {Z+1}][][end]")
+        niui_exit += jl.seval(f"avg[:niui, {Z+1}][][end]")
     end
     ui_avg = niui_exit / ni_exit
     


### PR DESCRIPTION
This makes a few changes to `thruster.py.`

First, the ion current calculation did not take into account the change in area that can occur across the discharge. This was the reason behind the ion current discrepancy we were seeing between versions. The effective area of the plume at the right boundary had changed but the ion current had not. Now we use the built-in `HallThruster.ion_current` function.

Second, I have updated the ui_avg calculation to be more representative. Properly, this should be weighted by the density of each species, so that if you have 90% singly-charged, 8% doubly-charged, and 2% triply-charged ions the average exit velocity would be closest to the singly-charged species. This gives an indication of the average charge state as well. 

In doing these, I am trying to use more of HallThruster.jl's built-in computations rather than saving them to disk and reloading. This hopefully will help avoid future issues like this.