### PR TITLE
feat: update pemv1 config to use new simplelogisticshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![build](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/deploy.yml?logo=github)
 ![docs](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/docs.yml?logo=materialformkdocs&logoColor=%2523cccccc&label=docs)
 ![tests](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/tests.yml?logo=github&logoColor=%2523cccccc&label=tests)
-![Code Coverage](https://img.shields.io/badge/coverage-88%25-yellowgreen?logo=codecov)
+![Code Coverage](https://img.shields.io/badge/coverage-89%25-yellowgreen?logo=codecov)
 [![Journal article](https://img.shields.io/badge/DOI-10.1007/s44205--024--00079--w-blue)](https://rdcu.be/dVmim)
 
 Prototype of a predictive engineering model (PEM) of a Hall thruster. Integrates sub-models from multiple disciplines to simulate a Hall thruster operating in a vacuum chamber. Uses uncertainty quantification techniques to extrapolate model predictions to a space-like environment.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,7 +19,7 @@ There are a few general scripts that can be used for any PEM configuration:
 ### Environment setup
 Installs `pdm` and the `hallmd` package. Also installs Julia and `HallThruster.jl`.
 ```shell
-source setup_env.sh --hallthruster-version=0.18.1 --julia-version=1.10
+source setup_env.sh --hallthruster-version=0.18.2 --julia-version=1.10
 ```
 
 ### Train a surrogate

--- a/scripts/install_hallthruster.py
+++ b/scripts/install_hallthruster.py
@@ -8,20 +8,20 @@ Usage: python install_hallthruster.py --julia-version 1.10 --hallthruster-versio
 
 Note: If `git-ref` is specified, this will override the `hallthruster-version` and instead install from GitHub.
 """
+
 import argparse
 import os
+import platform
 import shlex
 import subprocess
-import platform
 from pathlib import Path
 
 from packaging.version import Version
 
-
 ENV = os.environ.copy()
 PLATFORM = platform.system().lower()
 JULIA_VERSION_DEFAULT = "1.10"
-HALLTHRUSTER_VERSION_DEFAULT = "0.18.1"
+HALLTHRUSTER_VERSION_DEFAULT = "0.18.2"
 HALLTHRUSTER_URL = "https://github.com/UM-PEPL/HallThruster.jl"
 HALLTHRUSTER_NAME = "HallThruster"
 
@@ -46,7 +46,9 @@ def run_command(command, capture_output=True, text=None, shell=False, env=None):
                 command = shlex.split(command)
         return subprocess.run(command, capture_output=capture_output, check=True, text=text, shell=shell, env=env)
     except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Command `{command}` failed with code {e.returncode}: {e}\nError message: {e.stderr}") from e
+        raise RuntimeError(
+            f"Command `{command}` failed with code {e.returncode}: {e}\nError message: {e.stderr}"
+        ) from e
     except subprocess.SubprocessError as e:
         raise RuntimeError(f"Subprocess error: {e}") from e
 
@@ -62,7 +64,9 @@ def install_juliaup(yes: bool = False):
             cmd += " -s -- -y"
 
         run_command(cmd, capture_output=False, text=True, shell=True)
-        ENV["PATH"] = str((Path(os.path.expanduser('~')) / ".juliaup" / "bin").resolve()) + os.pathsep + ENV.get("PATH", "")
+        ENV["PATH"] = (
+            str((Path(os.path.expanduser('~')) / ".juliaup" / "bin").resolve()) + os.pathsep + ENV.get("PATH", "")
+        )
 
 
 def ensure_julia_version(julia_version):
@@ -126,13 +130,19 @@ def install_hallthruster_jl(hallthruster_version, git_ref):
         os.makedirs(env_path)
         if PLATFORM == 'windows':
             # Powershell needs the double quotes to be escaped
-            pkg_cmd = rf'Pkg.add(url=\"{HALLTHRUSTER_URL}\", rev=\"{git_ref}\")' if git_ref is not None else \
-                rf'Pkg.add(name=\"{HALLTHRUSTER_NAME}\", version=\"{hallthruster_version}\")'
+            pkg_cmd = (
+                rf'Pkg.add(url=\"{HALLTHRUSTER_URL}\", rev=\"{git_ref}\")'
+                if git_ref is not None
+                else rf'Pkg.add(name=\"{HALLTHRUSTER_NAME}\", version=\"{hallthruster_version}\")'
+            )
             pkg_cmd += r'; Pkg.add(\"JSON3\")'
             install_cmd = rf"julia -e 'using Pkg; Pkg.activate(raw\"{env_path.resolve()}\"); {pkg_cmd}'"
         else:
-            pkg_cmd = rf'Pkg.add(url="{HALLTHRUSTER_URL}", rev="{git_ref}")' if git_ref is not None else \
-                rf'Pkg.add(name="{HALLTHRUSTER_NAME}", version="{hallthruster_version}")'
+            pkg_cmd = (
+                rf'Pkg.add(url="{HALLTHRUSTER_URL}", rev="{git_ref}")'
+                if git_ref is not None
+                else rf'Pkg.add(name="{HALLTHRUSTER_NAME}", version="{hallthruster_version}")'
+            )
             pkg_cmd += r'; Pkg.add("JSON3")'
             install_cmd = rf"""julia -e 'using Pkg; Pkg.activate("{env_path.resolve()}"); {pkg_cmd}'"""
 
@@ -158,15 +168,22 @@ def main(julia_version, hallthruster_version, git_ref, yes):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Install specified Julia and HallThruster.jl versions.")
-    parser.add_argument("-j", "--julia-version", default=JULIA_VERSION_DEFAULT,
-                        help="The Julia version to install (default: 1.10)")
-    parser.add_argument("-t", "--hallthruster-version", default=HALLTHRUSTER_VERSION_DEFAULT,
-                        help="The HallThruster.jl version to install (default: 0.18.1)")
-    parser.add_argument("-r", "--git-ref", default=None,
-                        help="Install from this git ref (branch, hash, etc.) from the HallThruster.jl "
-                             "GitHub repository.")
-    parser.add_argument("-y", "--yes", action="store_true", default=False,
-                        help="Install non-interactively.")
+    parser.add_argument(
+        "-j", "--julia-version", default=JULIA_VERSION_DEFAULT, help="The Julia version to install (default: 1.10)"
+    )
+    parser.add_argument(
+        "-t",
+        "--hallthruster-version",
+        default=HALLTHRUSTER_VERSION_DEFAULT,
+        help="The HallThruster.jl version to install (default: 0.18.1)",
+    )
+    parser.add_argument(
+        "-r",
+        "--git-ref",
+        default=None,
+        help="Install from this git ref (branch, hash, etc.) from the HallThruster.jl GitHub repository.",
+    )
+    parser.add_argument("-y", "--yes", action="store_true", default=False, help="Install non-interactively.")
     args = parser.parse_args()
 
     main(args.julia_version, args.hallthruster_version, args.git_ref, args.yes)

--- a/scripts/install_hallthruster.py
+++ b/scripts/install_hallthruster.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
         "-t",
         "--hallthruster-version",
         default=HALLTHRUSTER_VERSION_DEFAULT,
-        help="The HallThruster.jl version to install (default: 0.18.1)",
+        help=f"The HallThruster.jl version to install (default: {HALLTHRUSTER_VERSION_DEFAULT})",
     )
     parser.add_argument(
         "-r",

--- a/scripts/pem_v1/pem_v1_SPT-100.yml
+++ b/scripts/pem_v1/pem_v1_SPT-100.yml
@@ -64,7 +64,6 @@ components: !Component
     version: 0.18.2
     thruster: SPT-100
     config:
-#      thruster: SPT-100                 # moved to separate thruster kwarg
       discharge_voltage: 300             # overwritten by V_a
       anode_mass_flow_rate: 5.0e-6       # overwritten by mdot_a
       cathode_coupling_voltage: 30       # overwritten by V_cc

--- a/scripts/pem_v1/pem_v1_SPT-100.yml
+++ b/scripts/pem_v1/pem_v1_SPT-100.yml
@@ -61,7 +61,7 @@ components: !Component
         domain: (0, 60)
   - name: Thruster
     model: !!python/name:hallmd.models.thruster.hallthruster_jl
-    version: 0.18.1
+    version: 0.18.2
     thruster: SPT-100
     config:
 #      thruster: SPT-100                 # moved to separate thruster kwarg
@@ -73,17 +73,16 @@ components: !Component
       neutral_velocity: 300              # overwritten by u_n
       ncharge: 1                         # overwritten by model_fidelity[1]
       anom_model:
-        type: LogisticPressureShift
+        type: SimpleLogisticShift
         model:
           type: GaussianBohm
           hall_min: 0.00625  # overwritten by anom_min
           hall_max: 0.0625   # overwritten by anom_max * anom_min
           center: 0.025      # overwritten by anom_center
           width: 0.005       # overwritten by anom_width
-        dz: 0.2              # overwritten by dz
-        z0: -0.03            # overwritten by z0
-        pstar: 45.0e-6       # overwritten by p0
-        alpha: 15
+        shift_length: 0.3    # overwritten by anom_shift_length
+        midpoint_pressure: 25.0e-6
+        slope: 2.0
       wall_loss_model:
         type: WallSheath
         material: BNSiO2
@@ -108,7 +107,7 @@ components: !Component
     postprocess:
       average_start_time: 0.0005  # s
     model_fidelity: (2, 2)
-    data_fidelity: (2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2)
+    data_fidelity: (2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2)
     inputs: !Variable
       - name: P_b
       - name: V_a
@@ -133,14 +132,14 @@ components: !Component
         description: minimum Hall parameter
         category: calibration
         tex: "$\\alpha_1$"
-        nominal: 0.00680237
+        nominal: 0.00625
         distribution: LogUniform(0.0001, 1.0)
         norm: log10
       - name: anom_max
         description: maximum Hall parameter
         category: calibration
         tex: "$\\alpha_2$"
-        nominal: 4.0
+        nominal: 10
         distribution: Uniform(1, 100)
       - name: anom_center
         description: location of gaussian trough in anom profile
@@ -155,29 +154,15 @@ components: !Component
         category: calibration
         units: m
         tex: "$L_{anom}$"
-        nominal: 0.01
+        nominal: 0.005
         distribution: Uniform(0.001, 0.05)
         norm: linear(1e3)
-      - name: dz
+      - name: anom_shift_length
         description: Anomalous shift displacement
         category: calibration
         tex: "$\\Delta_z$"
-        nominal: 0.4
-        distribution: N(0.2, 0.07)
-      - name: z0
-        description: Upstream anomalous shift axial limit
-        category: calibration
-        tex: "$z_0$"
-        nominal: -0.03
-        distribution: N(-0.12, 0.04)
-      - name: p0
-        description: Upstream anomalous shift pressure limit
-        category: calibration
-        tex: "$p_0$"
-        units: Torr
-        nominal: 56.86006e-6
-        distribution: N(45.0e-6, 7.0e-6)
-        norm: linear(1e6)
+        nominal: 0.3
+        distribution: Uniform(0, 0.5)
       - name: f_n
         description: Neutral ingestion multiplier
         category: calibration

--- a/scripts/pem_v1/train-shim.sh
+++ b/scripts/pem_v1/train-shim.sh
@@ -7,7 +7,7 @@
 # -p : use variable PDF weighting
 ./train.sh pem_v1/pem_v1_SPT-100.yml -c200 -t200 -e process -r1 -i150 -f both -N25 -m 1e-4 -C 5 -n 20 \
                                      --targets T I_B0 I_d u_ion \
-                                     --inputs P_b V_a a_1 a_2 \
+                                     --inputs P_b V_a anom_min anom_max \
                                      --outputs T I_B0 I_d u_ion \
                                      --show-model best worst \
                                      --gen-cpus 36 --fit-cpus 16 --slice-cpus 36 \

--- a/src/hallmd/models/pem_to_julia.json
+++ b/src/hallmd/models/pem_to_julia.json
@@ -16,6 +16,7 @@
     "anom_max": ["config", "anom_model", "model", "hall_max"],
     "anom_center": ["config", "anom_model", "model", "center"],
     "anom_width": ["config", "anom_model", "model", "width"],
+	"anom_shift_length": ["config", "anom_model", "shift_length"],
     "f_n": ["config", "neutral_ingestion_multiplier"],
 	"c_w": ["config", "wall_loss_model", "loss_scale"],
     "ncharge": ["config", "ncharge"],

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -32,7 +32,7 @@ from hallmd.utils import AVOGADRO_CONSTANT, FUNDAMENTAL_CHARGE, MOLECULAR_WEIGHT
 
 __all__ = ["run_hallthruster_jl", "hallthruster_jl", "get_jl_env", "PEM_TO_JULIA"]
 
-HALLTHRUSTER_VERSION_DEFAULT = "0.18.1"
+HALLTHRUSTER_VERSION_DEFAULT = "0.18.2"
 
 # Maps PEM variable names to a path in the HallThruster.jl input/output structure (default values here)
 with open(resources.files("hallmd.models") / "pem_to_julia.json", "r") as fd:
@@ -220,7 +220,7 @@ def _format_hallthruster_jl_input(
 
     # Handle special conversions for anomalous transport models
     if anom_model := json_config["config"].get("anom_model"):
-        if anom_model.get("type") == "LogisticPressureShift":
+        if anom_model.get("type") in ["LogisticPressureShift", "SimpleLogisticShift"]:
             anom_model = anom_model.get("model", {})
 
         match anom_model.get("type", "TwoZoneBohm"):

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -373,7 +373,7 @@ def hallthruster_jl(
                            via `ncells = model_fidelity[0] * 50 + 100` and `ncharge = model_fidelity[1] + 1`.
                            Will override `ncells` and `ncharge` in `simulation` and `config` if provided.
     :param output_path: base path to save output files, will write to current directory if not specified
-    :param version: version of HallThruster.jl to use (defaults to 0.18.1); will
+    :param version: version of HallThruster.jl to use; will
                     search for a global `hallthruster_{version}` environment in the `~/.julia/environments/` directory.
                     Can also specify a specific git ref (i.e. branch, commit hash, etc.) to use from GitHub. If the
                     `hallthruster_{version}` environment does not exist, an error will be raised -- you should create


### PR DESCRIPTION
This PR updates the PEMv1 config to use the new HallThruster.jl `SimpleLogisticShift` model instead of the old `LogisticPressureShift`. This removes the need to infer a `z0` parameter entirely. Additionally, we are fixing the midpoint pressure to 25 microTorr, which seems to work well for both the SPT100 and H9. This leaves only one parameter to calibrate for the pressure shift model.