### PR TITLE
refactor: plume model now takes radius as kwarg instead of input

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,14 +5,14 @@
 groups = ["default", "dev", "doc", "mpi", "scripts", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:38b60aecfdc5ba173de673bf30ce3d66a912164927045e103a4d2904cd5ffce9"
+content_hash = "sha256:c3aaeefb04e07690cdb0bc3be75f48a6927cc5082f24bcd83f2d77b72c5de440"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
 
 [[package]]
 name = "amisc"
-version = "0.7.0"
+version = "0.7.1"
 requires_python = ">=3.11"
 summary = "Efficient framework for building surrogates of multidisciplinary systems using the adaptive multi-index stochastic collocation (AMISC) technique."
 groups = ["default"]
@@ -26,8 +26,8 @@ dependencies = [
     "scipy>=1.14",
 ]
 files = [
-    {file = "amisc-0.7.0-py3-none-any.whl", hash = "sha256:b0d5c1ae1c89e8f48a3ddd55d5c12ce606cf96951649d330869037728038dc46"},
-    {file = "amisc-0.7.0.tar.gz", hash = "sha256:7eb7fc05fac50c7a898729f3b878f2a1440d78ff85c5e042da835480c59a4d99"},
+    {file = "amisc-0.7.1-py3-none-any.whl", hash = "sha256:a52d6bc6d920c4ba204a820bbd2d925ad0cd0c02e9a38c4339f89dd3662021c1"},
+    {file = "amisc-0.7.1.tar.gz", hash = "sha256:63f373bf2c139ff0c3e01199105ce31266a91622e24868165191676077b7ed19"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 dependencies = [
     "numpy>=2.0",
     "scipy>=1.14",
-    "amisc>=0.7.0",
+    "amisc>=0.7.1",
 ]
 requires-python = ">=3.11"
 readme = "README.md"

--- a/scripts/gen_data.py
+++ b/scripts/gen_data.py
@@ -289,19 +289,16 @@ def process_compression(system: System, data: dict, discard_outliers: bool = Fal
 
 
 def plot_outliers(outputs: dict, outlier_idx: dict, iqr_factor: float = 1.5, subplot_size: float = 3,
-                  fields_1d: list[str] = None, fields_log: dict = None):
+                  fields_log: dict = None):
     """Plot histograms of outliers detected in the output data at the given indices.
 
     :param outputs: dictionary of output arrays, where each array has shape `(num_samples, ...)`.
     :param outlier_idx: dictionary with boolean arrays of shape `(num_samples,)` indicating outliers for each output
     :param iqr_factor: the factor to multiply the IQR by to determine outliers. Defaults to 1.5.
     :param subplot_size: the size of each subplot in inches. Defaults to 2.5.
-    :param fields_1d: a list of field quantities to plot as 1D line plots. Defaults to `['u_ion', 'j_ion']`. Otherwise,
-           all field quantities will be plotted as histograms of the mean value.
     :param fields_log: a dictionary of field qtys to set the y-axis to log scale. Defaults to {'j_ion': True}.
     :returns: the `fig, ax` for the plot
     """
-    fields_1d = fields_1d or ['u_ion', 'j_ion']
     fields_log = fields_log or {'j_ion': True}
     num_plots = len(outlier_idx.keys())
     num_col = int(np.floor(np.sqrt(num_plots)))
@@ -325,8 +322,10 @@ def plot_outliers(outputs: dict, outlier_idx: dict, iqr_factor: float = 1.5, sub
         lb_iqr = p25 - iqr_factor * iqr
         ub_iqr = p75 + iqr_factor * iqr
 
+        is_1d_field = len(np.atleast_1d(p50).shape) == 1 and np.atleast_1d(p50).shape[0] > 1
+
         # Line plots for 1d field quantities
-        if var in fields_1d:
+        if is_1d_field:
             coords = np.linspace(0, 1, len(p50))
             ax.plot(coords, p50, '-k', label='Median')
             ax.fill_between(coords, lb_iqr, ub_iqr, alpha=0.5, edgecolor=(0.5, 0.5, 0.5), facecolor='gray',

--- a/scripts/pem_v0/pem_v0_SPT-100.yml
+++ b/scripts/pem_v0/pem_v0_SPT-100.yml
@@ -215,6 +215,7 @@ components: !Component
   - name: Plume
     model: !!python/name:hallmd.models.plume.current_density
     vectorized: true
+    sweep_radius: 1.0
     inputs: !Variable
       - name: P_b
       - name: c0
@@ -267,13 +268,6 @@ components: !Component
         nominal: 55.0e-20
         distribution: Uniform(51.0e-20, 58.0e-20)
         norm: linear(1e20)
-      - name: r_p
-        description: Plume measurement radial distance from channel exit
-        category: operating
-        tex: "$r_p$"
-        units: m
-        nominal: 1
-        domain: (0.5, 1.5)
       - name: I_B0
     outputs: !Variable
       - name: j_ion

--- a/scripts/pem_v0/pem_v0_SPT-100.yml
+++ b/scripts/pem_v0/pem_v0_SPT-100.yml
@@ -215,7 +215,7 @@ components: !Component
   - name: Plume
     model: !!python/name:hallmd.models.plume.current_density
     vectorized: true
-    sweep_radius: 1.0
+    sweep_radius: 1.0  # must be scalar for j_ion compression
     inputs: !Variable
       - name: P_b
       - name: c0

--- a/scripts/pem_v1/pem_v1_SPT-100.yml
+++ b/scripts/pem_v1/pem_v1_SPT-100.yml
@@ -221,6 +221,7 @@ components: !Component
   - name: Plume
     model: !!python/name:hallmd.models.plume.current_density
     vectorized: true
+    sweep_radius: 1.0
     inputs: !Variable
       - name: P_b
       - name: c0
@@ -273,13 +274,6 @@ components: !Component
         nominal: 55.0e-20
         distribution: Uniform(51.0e-20, 58.0e-20)
         norm: linear(1e20)
-      - name: r_p
-        description: Plume measurement radial distance from channel exit
-        category: operating
-        tex: "$r_p$"
-        units: m
-        nominal: 1
-        domain: (0.5, 1.5)
       - name: I_B0
       - name: T
     outputs: !Variable

--- a/scripts/pem_v1/pem_v1_SPT-100.yml
+++ b/scripts/pem_v1/pem_v1_SPT-100.yml
@@ -282,9 +282,6 @@ components: !Component
         tex: "$j_{ion}$"
         units: "$A/m^2$"
         norm: log10
-        compression:
-          method: svd
-          reconstruction_tol: 0.01
       - name: div_angle
         description: Divergence angle
         tex: "$\\theta_d$"

--- a/src/hallmd/models/plume.py
+++ b/src/hallmd/models/plume.py
@@ -18,15 +18,19 @@ __all__ = ['current_density']
 LOGGER = get_logger(__name__)
 
 
-def current_density(inputs: Dataset, sweep_radius=1.0):
+def current_density(inputs: Dataset, sweep_radius: float | list = 1.0):
     """Compute the semi-empirical ion current density ($j_{ion}$) plume model over a 90 deg sweep, with 0 deg at
     thruster centerline. Also compute the plume divergence angle. Will return the ion current density at 91 points,
     from 0 to 90 deg in 1 deg increments. The angular locations are returned as `j_ion_coords` in radians.
 
-    :param inputs: input arrays - `P_b`, `c0`, `c1`, `c2`, `c3`, `c4`, `c5`, `sigma_cex`, `r_p`, `I_B0` for background
-                   pressure (Torr), plume fit coefficients, charge-exchange cross-section ($m^2$), radial distance
-                   from thruster exit plane (m), and total initial ion beam current (A). If `T` is provided, then
+    :param inputs: input arrays - `P_b`, `c0`, `c1`, `c2`, `c3`, `c4`, `c5`, `sigma_cex`, `I_B0` for background
+                   pressure (Torr), plume fit coefficients, charge-exchange cross-section ($m^2$),
+                   and total initial ion beam current (A). If `T` is provided, then
                    also compute corrected thrust using the divergence angle.
+    :param sweep_radius: the location(s) at which to compute the ion current density 90 deg sweep, in units of radial
+                         distance (m) from the thruster exit plane. If multiple locations are provided, then the
+                         returned $j_{ion}$ array's last dimension will match the length of `sweep_radius`. Defaults to
+                         1 meter.
     :returns outputs: output arrays - `j_ion` for ion current density ($A/m^2$) at the `j_ion_coords` locations,
                                        and `div_angle` in radians for the divergence angle of the plume. Optionally,
                                        `T_c` for corrected thrust (N) if `T` is provided in the inputs.
@@ -42,6 +46,7 @@ def current_density(inputs: Dataset, sweep_radius=1.0):
     sigma_cex = inputs['sigma_cex']  # Charge-exchange cross-section (m^2)
     I_B0 = inputs['I_B0']  # Total initial ion beam current (A)
     thrust = inputs.get('T', None)  # Thrust (N)
+    sweep_radius = np.atleast_1d(sweep_radius)
 
     # 90 deg angle sweep for ion current density
     alpha_rad = np.linspace(0, np.pi / 2, 91)
@@ -77,17 +82,26 @@ def current_density(inputs: Dataset, sweep_radius=1.0):
                 - erfi((np.pi * 1j + (alpha2**2)) / (2 * alpha2))
             )
         )
-        I_B = I_B0 * np.exp(-sweep_radius * n * sigma_cex)
+        # Broadcast over angles and radii (..., a, r)
+        A1 = np.expand_dims(A1, axis=(-1, -2))  # (..., 1, 1)
+        A2 = np.expand_dims(A2, axis=(-1, -2))
+        alpha1 = np.expand_dims(alpha1, axis=(-1, -2))
+        alpha2 = np.expand_dims(alpha2, axis=(-1, -2))
+        I_B0 = np.expand_dims(I_B0, axis=(-1, -2))
+        n = np.expand_dims(n , axis=(-1, -2))
+        sigma_cex = np.expand_dims(sigma_cex, axis=(-1, -2))
 
-        base_density = np.atleast_1d(I_B / sweep_radius**2)[..., np.newaxis]
-        j_beam = base_density * A1[..., np.newaxis] * np.exp(-((alpha_rad / alpha1[..., np.newaxis]) ** 2))
-        j_scat = base_density * A2[..., np.newaxis] * np.exp(-((alpha_rad / alpha2[..., np.newaxis]) ** 2))
-        j_cex = I_B0 * (1 - np.exp(-sweep_radius * n * sigma_cex)) / (2 * np.pi * sweep_radius**2)
-        j_cex = np.atleast_1d(j_cex)[..., np.newaxis]
-        j_ion = j_beam + j_scat + j_cex  # (..., 91) the current density 1d profile
+        decay = np.exp(-sweep_radius * n * sigma_cex)  # (..., 1, r)
+        j_cex = I_B0 * (1 - decay) / (2 * np.pi * sweep_radius ** 2)
+
+        base_density = I_B0 * decay / sweep_radius ** 2
+        j_beam = base_density * A1 * np.exp(-((alpha_rad[..., np.newaxis] / alpha1) ** 2))
+        j_scat = base_density * A2 * np.exp(-((alpha_rad[..., np.newaxis] / alpha2) ** 2))
+
+        j_ion = j_beam + j_scat + j_cex  # (..., 91, r) the current density 1d profile at r radial locations
 
     # Set j~0 where alpha1 < 0 (invalid cases)
-    invalid_idx = np.logical_or(alpha1 <= 0, np.any(j_ion <= 0, axis=-1))
+    invalid_idx = np.logical_or(np.any(alpha1 <= 0, axis=(-1, -2)), np.any(j_ion <= 0, axis=(-1, -2)))
     j_ion[invalid_idx, ...] = 1e-20
     j_cex[invalid_idx, ...] = 1e-20
 
@@ -99,22 +113,30 @@ def current_density(inputs: Dataset, sweep_radius=1.0):
     # Requires alpha = [0, ..., 90] deg, from thruster exit-plane to thruster centerline (need to flip)
     # do j_beam + j_scat instead of j_ion - j_cex to avoid catastrophic loss of precision when
     # j_beam and j_scat << j_cex
-    j_non_cex = np.flip((j_beam + j_scat).real, axis=-1)
-    den_integrand = j_non_cex * np.cos(alpha_rad)
-    num_integrand = den_integrand * np.sin(alpha_rad)
+    j_non_cex = np.flip((j_beam + j_scat).real, axis=-2)
+    den_integrand = j_non_cex * np.cos(alpha_rad[..., np.newaxis])
+    num_integrand = den_integrand * np.sin(alpha_rad[..., np.newaxis])
 
     with np.errstate(divide='ignore', invalid='ignore'):
-        num = simpson(num_integrand, x=alpha_rad, axis=-1)
-        den = simpson(den_integrand, x=alpha_rad, axis=-1)
+        num = simpson(num_integrand, x=alpha_rad, axis=-2)
+        den = simpson(den_integrand, x=alpha_rad, axis=-2)
         cos_div = np.atleast_1d(num / den)
         cos_div[cos_div == np.inf] = np.nan
 
-    div_angle = np.arccos(cos_div)  # Divergence angle (rad)
+    div_angle = np.arccos(cos_div)  # Divergence angle (rad) - (..., r)
+
+    # Squeeze last dim if only a single radius was passed
+    if sweep_radius.shape[0] == 1:
+        j_ion = np.squeeze(j_ion, axis=-1)
+        div_angle = np.squeeze(div_angle, axis=-1)
 
     ret = {'j_ion': j_ion, 'div_angle': div_angle}
 
     if thrust is not None:
-        ret['T_c'] = thrust * cos_div
+        thrust_corrected = np.expand_dims(thrust, axis=-1) * cos_div
+        if sweep_radius.shape[0] == 1:
+            thrust_corrected = np.squeeze(thrust_corrected, axis=-1)
+        ret['T_c'] = thrust_corrected
 
     # Interpolate to requested angles
     # if j_ion_coords is not None:
@@ -126,8 +148,9 @@ def current_density(inputs: Dataset, sweep_radius=1.0):
     #     j_ion = f(j_ion_coords)  # (..., num_pts)
 
     # Broadcast coords to same loop shape as j_ion (all use the same coords -- store in object array)
-    j_ion_coords = np.empty(j_ion.shape[:-1], dtype=object)
-    for index in np.ndindex(j_ion.shape[:-1]):
+    last_axis = -1 if sweep_radius.shape[0] == 1 else -2
+    j_ion_coords = np.empty(j_ion.shape[:last_axis], dtype=object)
+    for index in np.ndindex(j_ion.shape[:last_axis]):
         j_ion_coords[index] = alpha_rad
 
     ret['j_ion_coords'] = j_ion_coords

--- a/src/hallmd/utils.py
+++ b/src/hallmd/utils.py
@@ -23,7 +23,7 @@ MOLECULAR_WEIGHTS = {
     'Krypton': 83.798,
     'Bismuth': 208.98,
     'Hydrogen': 1.008,
-    'Mecury': 200.59
+    'Mercury': 200.59
 }
 
 

--- a/tests/test_plume.py
+++ b/tests/test_plume.py
@@ -7,8 +7,8 @@ from scipy.integrate import simpson
 from hallmd.models.plume import current_density
 
 SHOW_PLOTS = False  # for debugging
-J_MIN = 1e-6  # Minimum expected ion current density
-J_MAX = 1e3  # Maximum expected ion current density
+J_MIN = 0  # Minimum expected ion current density
+J_MAX = 5e3  # Maximum expected ion current density
 N = 100  # Number of grid points
 
 
@@ -26,8 +26,10 @@ def test_random_samples(plots=SHOW_PLOTS):
         'I_B0': np.random.rand(N) * 6 + 2,
     }
 
-    r_p = np.random.rand(N) * 0.4 + 0.8
+    r_p = np.random.rand(25) * 0.2 + 1
     outputs_rand = current_density(inputs_rand, sweep_radius=r_p)
+
+    assert outputs_rand['j_ion'].shape == (N, 91, 25)  # (..., angles, radii)
 
     min_jion = np.min(outputs_rand['j_ion'])
     max_jion = np.max(outputs_rand['j_ion'])
@@ -41,10 +43,10 @@ def test_random_samples(plots=SHOW_PLOTS):
     if plots:
         # Plot bounds of random samples
         jion = outputs_rand['j_ion']
-        alpha_deg = np.linspace(0, np.pi / 2, jion.shape[-1]) * (180 / np.pi)
-        lb = np.percentile(jion, 5, axis=0)
-        mid = np.percentile(jion, 50, axis=0)
-        ub = np.percentile(jion, 95, axis=0)
+        alpha_deg = np.linspace(0, np.pi / 2, jion.shape[-2]) * (180 / np.pi)
+        lb = np.percentile(jion, 5, axis=(0, 2))
+        mid = np.percentile(jion, 50, axis=(0, 2))
+        ub = np.percentile(jion, 95, axis=(0, 2))
 
         fig, ax = plt.subplots()
         ax.plot(alpha_deg, mid, '-k')


### PR DESCRIPTION
The plume radius is now a kwarg in the config instead of an amisc input/output.
I think this should "just work" with arrays, as well.

![maxresdefault](https://github.com/user-attachments/assets/7f099093-bae3-4bd0-a816-bfe15bf3d6ff)
