### PR TITLE
Handle simulation errors in train scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![build](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/deploy.yml?logo=github)
 ![docs](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/docs.yml?logo=materialformkdocs&logoColor=%2523cccccc&label=docs)
 ![tests](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/tests.yml?logo=github&logoColor=%2523cccccc&label=tests)
-![Code Coverage](https://img.shields.io/badge/coverage-89%25-yellowgreen?logo=codecov)
+![Code Coverage](https://img.shields.io/badge/coverage-88%25-yellowgreen?logo=codecov)
 [![Journal article](https://img.shields.io/badge/DOI-10.1007/s44205--024--00079--w-blue)](https://rdcu.be/dVmim)
 
 Prototype of a predictive engineering model (PEM) of a Hall thruster. Integrates sub-models from multiple disciplines to simulate a Hall thruster operating in a vacuum chamber. Uses uncertainty quantification techniques to extrapolate model predictions to a space-like environment.

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,14 +5,14 @@
 groups = ["default", "dev", "doc", "mpi", "scripts", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:c3aaeefb04e07690cdb0bc3be75f48a6927cc5082f24bcd83f2d77b72c5de440"
+content_hash = "sha256:17840875f917cc11362ab3d3b98ef9020392cfc834a9734845c6efe4d7bf3d11"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
 
 [[package]]
 name = "amisc"
-version = "0.7.1"
+version = "0.7.3"
 requires_python = ">=3.11"
 summary = "Efficient framework for building surrogates of multidisciplinary systems using the adaptive multi-index stochastic collocation (AMISC) technique."
 groups = ["default"]
@@ -26,8 +26,8 @@ dependencies = [
     "scipy>=1.14",
 ]
 files = [
-    {file = "amisc-0.7.1-py3-none-any.whl", hash = "sha256:a52d6bc6d920c4ba204a820bbd2d925ad0cd0c02e9a38c4339f89dd3662021c1"},
-    {file = "amisc-0.7.1.tar.gz", hash = "sha256:63f373bf2c139ff0c3e01199105ce31266a91622e24868165191676077b7ed19"},
+    {file = "amisc-0.7.3-py3-none-any.whl", hash = "sha256:1c4d42a967009d25bb5a913a401878db224a172dc459304a0be9ced0e684aa80"},
+    {file = "amisc-0.7.3.tar.gz", hash = "sha256:94a8746a570852db57a36b3300ee7c28d9674585795f8d67ac901764c1c42e2f"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 dependencies = [
     "numpy>=2.0",
     "scipy>=1.14",
-    "amisc>=0.7.1",
+    "amisc>=0.7.3",
 ]
 requires-python = ">=3.11"
 readme = "README.md"

--- a/scripts/fit_surr.py
+++ b/scripts/fit_surr.py
@@ -261,7 +261,7 @@ if __name__ == '__main__':
                     discard_idx |= idx
 
             test_set = ({k: v[~discard_idx, ...] for k, v in data['test_set'][0].items()},
-                        {k: v[~discard_idx, ...] for k, v in data['test_set'][1].items()})
+                        {k: v[~discard_idx, ...] for k, v in data['test_set'][1].items() if k != 'errors'})
 
     with pool_executor(max_workers=args.fit_cpus) as executor:
         fit_kwargs = {'runtime_hr': args.runtime_hr, 'max_iter': args.max_iter, 'targets': args.targets,

--- a/scripts/gen_data.py
+++ b/scripts/gen_data.py
@@ -111,7 +111,13 @@ def _object_to_numeric(array: np.ndarray):
     Will only work assuming each field quantity has the same shape (which should be true for compression data).
     """
     if np.issubdtype(array.dtype, np.object_):
-        return np.concatenate([arr[np.newaxis, ...] for arr in array], axis=0)
+        shape = ()
+        for arr in array:
+            if arr is not None:
+                shape = arr.shape
+                break
+        return np.concatenate([arr[np.newaxis, ...] if arr is not None else np.full((1, *shape), np.nan)
+                               for arr in array], axis=0)
     else:
         return array
 
@@ -134,7 +140,7 @@ def _filter_outputs(outputs: dict, iqr_factor: float = 1.5):
     cnt_thresh = 0.75  # Only count a QoI as an outlier if more than 75% of its values are outliers; always true for scalars
 
     for var, arr in outputs.items():
-        if COORDS_STR_ID in str(var):
+        if COORDS_STR_ID in str(var) or str(var) == 'errors':
             continue
 
         try:

--- a/scripts/install_hallthruster.py
+++ b/scripts/install_hallthruster.py
@@ -21,7 +21,7 @@ from packaging.version import Version
 ENV = os.environ.copy()
 PLATFORM = platform.system().lower()
 JULIA_VERSION_DEFAULT = "1.10"
-HALLTHRUSTER_VERSION_DEFAULT = "0.18.2"
+HALLTHRUSTER_VERSION_DEFAULT = "0.18.3"
 HALLTHRUSTER_URL = "https://github.com/UM-PEPL/HallThruster.jl"
 HALLTHRUSTER_NAME = "HallThruster"
 

--- a/scripts/pem_v1/pem_v1_SPT-100.yml
+++ b/scripts/pem_v1/pem_v1_SPT-100.yml
@@ -61,7 +61,7 @@ components: !Component
         domain: (0, 60)
   - name: Thruster
     model: !!python/name:hallmd.models.thruster.hallthruster_jl
-    version: 0.18.2
+    version: 0.18.3
     thruster: SPT-100
     config:
       discharge_voltage: 300             # overwritten by V_a
@@ -132,7 +132,7 @@ components: !Component
         category: calibration
         tex: "$\\alpha_1$"
         nominal: 0.00625
-        distribution: LogUniform(0.0001, 1.0)
+        distribution: LogUniform(0.001, 0.1)
         norm: log10
       - name: anom_max
         description: maximum Hall parameter
@@ -173,7 +173,7 @@ components: !Component
         category: calibration
         tex: "$c_w$"
         nominal: 1.0
-        distribution: U(0.1, 1.0)
+        distribution: U(0.5, 1.5)
       - name: V_cc
     outputs: !Variable
       - name: I_B0

--- a/scripts/pem_v1/train-shim.sh
+++ b/scripts/pem_v1/train-shim.sh
@@ -5,7 +5,7 @@
 # Optional:
 # -d : discard outliers
 # -p : use variable PDF weighting
-./train.sh pem_v1/pem_v1_SPT-100.yml -c200 -t200 -e process -r1 -i150 -f both -N25 -m 1e-4 -C 5 -n 20 \
+./train.sh pem_v1/pem_v1_SPT-100.yml -c200 -t200 -e process -r1 -i150 -f multi -N25 -m 1e-4 -C 5 -n 20 \
                                      --targets T I_B0 I_d u_ion \
                                      --inputs P_b V_a anom_min anom_max \
                                      --outputs T I_B0 I_d u_ion \

--- a/src/hallmd/models/thruster.py
+++ b/src/hallmd/models/thruster.py
@@ -32,7 +32,7 @@ from hallmd.utils import AVOGADRO_CONSTANT, FUNDAMENTAL_CHARGE, MOLECULAR_WEIGHT
 
 __all__ = ["run_hallthruster_jl", "hallthruster_jl", "get_jl_env", "PEM_TO_JULIA"]
 
-HALLTHRUSTER_VERSION_DEFAULT = "0.18.2"
+HALLTHRUSTER_VERSION_DEFAULT = "0.18.3"
 
 # Maps PEM variable names to a path in the HallThruster.jl input/output structure (default values here)
 with open(resources.files("hallmd.models") / "pem_to_julia.json", "r") as fd:
@@ -338,6 +338,7 @@ def hallthruster_jl(
     fidelity_function: Callable[[tuple[int, ...]], dict] = "default",
     julia_script: str | Path = None,
     run_kwargs: dict = "default",
+    shock_threshold: float = None,
 ) -> Dataset:
     """Run a single `HallThruster.jl` simulation for a given set of inputs. This function will write a temporary
     input file to disk, call `HallThruster.run_simulation()` in Julia, and read the output file back into Python. Will
@@ -391,6 +392,10 @@ def hallthruster_jl(
                          a command line argument. Defaults to just calling `HallThruster.run_simulation(input_file)`.
     :param run_kwargs: additional keyword arguments to pass to `subprocess.run` when calling the Julia script.
                        Defaults to `check=True`.
+    :param shock_threshold: if provided, an error will be raised if the ion velocity reaches a maximum before this
+                            threshold axial location (in m) - used to detect and filter unwanted "shock-like" behavior,
+                            for example by providing a threshold of half the domain length. If not provided, then no
+                            filtering is performed (default).
     :returns: `dict` of `Hallthruster.jl` outputs: `I_B0`, `I_d`, `T`, `eta_c`, `eta_m`, `eta_v`, and `u_ion` for ion
               beam current (A), discharge current (A), thrust (N), current efficiency, mass efficiency, voltage
               efficiency, and singly-charged ion velocity profile (m/s), all time-averaged.
@@ -437,6 +442,14 @@ def hallthruster_jl(
     beam_current = thruster_outputs.get("I_B0", 0)
     if thrust < 0 or beam_current < 0:
         raise ValueError(f"Exception due to non-physical case: thrust={thrust} N, beam current={beam_current} A")
+
+    # Raise an exception for ion velocity that exhibits "shock" behavior
+    if shock_threshold is not None:
+        z_coords = thruster_outputs.get("u_ion_coords")
+        ion_velocity = thruster_outputs.get("u_ion")
+        if z_coords is not None and ion_velocity is not None:
+            if (z_max := z_coords[np.argmax(ion_velocity)]) < shock_threshold:
+                raise ValueError(f"Exception due to shock-like behavior: max ion velocity occurs at z={z_max:.3f} m")
 
     thruster_outputs["model_cost"] = t2 - t1  # seconds
 

--- a/tests/test_thruster.py
+++ b/tests/test_thruster.py
@@ -176,8 +176,8 @@ def test_run_hallthruster_jl(tmp_path, plots=SHOW_PLOTS, git_ref="0.18.1"):
     if plots:
         fig, ax = plt.subplots(1, 3, figsize=(12, 4), layout="tight")
         grid = outputs["u_ion_coords"]
-        ax[0].plot(grid, outputs["u_ion"], "-k", label="$z_0 = 3\%$")
-        ax[0].plot(grid, outputs_shift["u_ion"], "--r", label="$z_0 = 15\%$")
+        ax[0].plot(grid, outputs["u_ion"], "-k", label="$z_0 = 0.03$")
+        ax[0].plot(grid, outputs_shift["u_ion"], "--r", label="$z_0 = 0.15$")
         ax[0].set_xlabel("Axial distance from anode (m)")
         ax[0].set_ylabel("Ion velocity (m/s)")
         ax[0].legend()
@@ -187,8 +187,8 @@ def test_run_hallthruster_jl(tmp_path, plots=SHOW_PLOTS, git_ref="0.18.1"):
             data = json.load(fd)
             anom_shift = data["output"]["average"]["nu_anom"]
 
-        ax[1].plot(grid, nu_anom, "-k", label="$z_0 = 3\%$")
-        ax[1].plot(grid, anom_shift, "--r", label="$z_0 = 15\%$")
+        ax[1].plot(grid, nu_anom, "-k", label="$z_0 = 0.03$")
+        ax[1].plot(grid, anom_shift, "--r", label="$z_0 = 0.15$")
         ax[1].set_xlabel("Axial distance from anode (m)")
         ax[1].set_ylabel("Anomalous collision frequency (Hz)")
         ax[1].set_yscale("log")


### PR DESCRIPTION
## Proposed Changes

  - Updates amisc to `0.7.3` -- some bugs with compression for empty field values are fixed.
  - Updates surrogate training scripts to handle when the `hallthruster_jl` function raises an exception (which includes when HallThruster.jl itself fails for any reason).
  - Adds a flag for `hallthruster_jl` to optionally filter by `shock_threshold`, i.e. when shock-like behavior with ion velocity peaking early is observed.
  - Updates to HallThruster.jl 0.18.3.
  - Updates parameter ranges for `anom_min` and `c_w`.
