### PR TITLE
Extension to add variable magnetic field as operating condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@
 ![build](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/deploy.yml?logo=github)
 ![docs](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/docs.yml?logo=materialformkdocs&logoColor=%2523cccccc&label=docs)
 ![tests](https://img.shields.io/github/actions/workflow/status/JANUS-Institute/HallThrusterPEM/tests.yml?logo=github&logoColor=%2523cccccc&label=tests)
-![Code Coverage](https://img.shields.io/badge/coverage-78%25-yellowgreen?logo=codecov)
+![Code Coverage](https://img.shields.io/badge/coverage-73%25-yellow?logo=codecov)
 [![Journal article](https://img.shields.io/badge/DOI-10.1007/s44205--024--00079--w-blue)](https://rdcu.be/dVmim)
 
-A prototype of a predictive engineering model (PEM) of a Hall thruster.
-Integrates sub-models from multiple disciplines to simulate a Hall thruster operating in a vacuum chamber.
-Uses uncertainty quantification techniques to extrapolate model predictions to a space-like environment.
+Prototype of a predictive engineering model (PEM) of a Hall thruster. Integrates sub-models from multiple disciplines to simulate a Hall thruster operating in a vacuum chamber. Uses uncertainty quantification techniques to extrapolate model predictions to a space-like environment.
 
 ## ⚙️ Installation
 Ensure you are using Python 3.11 or later. You can install using [pdm](https://github.com/pdm-project/pdm):
@@ -22,30 +20,26 @@ cd HallThrusterPEM
 pdm install --prod
 ```
 
-`hallmd` uses the [`HallThruster.jl`](https://github.com/UM-PEPL/HallThruster.jl) Julia package.
-Please see their docs for setting up Julia and installing.
-Alternatively, you may run the provided [install script](https://raw.githubusercontent.com/JANUS-Institute/HallThrusterPEM/refs/heads/main/scripts/install_hallthruster.py), which will install both Julia and `HallThruster.jl`.
-By default, this will install Julia 1.11 and HallThruster.jl version 0.18.7.
-From the root directory, run the following command:
+`hallmd` uses the [`HallThruster.jl`](https://github.com/UM-PEPL/HallThruster.jl) Julia package. Please see their docs for setting up Julia and installing. Alternatively, you may run the provided [install script](https://raw.githubusercontent.com/JANUS-Institute/HallThrusterPEM/refs/heads/main/scripts/install_hallthruster.py), which will install both Julia and `HallThruster.jl`.
 
-```
-pdm run scripts/install_hallthruster.py --julia-version=X.XX.X --hallthruster-version=V.VV.V
-```
+Assuming `python` is available on your path:
 
-This will create a fresh Julia environment called `hallthruster_V.VV.V` and install `HallThruster.jl` there.
+=== "Linux/Mac"
+    ```shell
+    curl -sSL https://raw.githubusercontent.com/JANUS-Institute/HallThrusterPEM/refs/heads/main/scripts/install_hallthruster.py | python -
+    ```
 
-## 📍 Scripts used for publications
-See the [scripts](https://github.com/JANUS-Institute/HallThrusterPEM/blob/main/scripts) folder for workflows for data generation, parameter inference, and analysis using `hallmd`.
-This directory also contains information needed to replicate the results in our publications.
+=== "Windows"
+    ```shell
+    powershell -c "Invoke-WebRequest -Uri https://raw.githubusercontent.com/JANUS-Institute/HallThrusterPEM/refs/heads/main/scripts/install_hallthruster.py | python -"
+    ```
 
-## 📍 Standalone usage
-
-Below, we demonstrate how to use `hallmd` to run HallThruster.jl on a simple config file.
-
+## 📍 Quickstart
 ```python
 import matplotlib.pyplot as plt
 
 from hallmd.models import hallthruster_jl
+
 
 config = {
     'discharge_voltage': 300,

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "doc", "mpi", "scripts", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:58927abcf2ce29fcf0eaccbc4d3270b181ce7cc66a7ed4584ccdf85896eec389"
+content_hash = "sha256:084a69bdc69fbd93e34c222cccfc7b9df87ffdcb1544931df5d2597ddef51c12"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -933,7 +933,7 @@ version = "0.0.0"
 git = "https://github.com/archermarx/MCMCIterators"
 revision = "b98c7ba1631092187605f91d0b12bf0645e9a95d"
 summary = "Markov Chain Monte Carlo Iterators"
-groups = ["scripts"]
+groups = ["default", "scripts"]
 
 [[package]]
 name = "mergedeep"

--- a/scripts/mcmc_run.py
+++ b/scripts/mcmc_run.py
@@ -1,13 +1,4 @@
-import argparse
-import os
-
-import numpy as np
-import pem_mcmc as mcmc
-from install_hallthruster import main as install_hallthruster
-
-import hallmd.data
-
-desc_str = """`mcmc_run.py`
+"""`mcmc.py`
 
 This script is used to run MCMC on the cathode-thruster-plume system.
 
@@ -17,9 +8,18 @@ That folder in turn contains folders (numbered 000000 - num_samples) that hold t
 Additionally, each sample, its log-pdf, and whether it was accepted are written to a file called mcmc.csv in the main mcmc directory.
 
 For usage details and a full list of options , run 'pdm run scripts/run_mcmc.py --help'
+
 """  # noqa: E501
 
-parser = argparse.ArgumentParser(prog="mcmc_run.py", description=desc_str)
+import argparse
+import os
+
+import numpy as np
+import pem_mcmc as mcmc
+
+import hallmd.data
+
+parser = argparse.ArgumentParser(description="MCMC scripts")
 
 parser.add_argument(
     "config_file",
@@ -99,13 +99,14 @@ parser.add_argument(
 parser.add_argument(
     "--sampler",
     type=str,
-    choices=["dram", "prior", "prev-run"],
+    choices=["dram", "prior", "prev-run", "fixed"],
     default="dram",
     help="""
     The type of sampler to use
     - `dram`: the delayed-rejection adaptive metropolis sampler
     - `prior`: sample from the variable prior distributions only
     - `prev-run`: draw randomly (with replacement) from the samples of a previous run.
+    - `fixed` : evaluates only the initial sample
 
     The `prev-run` sampler requires the --prev argument to be passed.
     """,
@@ -135,17 +136,6 @@ def _update_opts(opts, root_dir, sample_index):
 
 def main(args):
     system, opts = mcmc.load_system_and_opts(args)
-
-    # Check for correct Hallthruster.jl version and install it if not present
-    hallthruster_version = system.get_component("Thruster").model_kwargs["version"]
-    install_hallthruster(
-        julia_version=None,
-        hallthruster_version=hallthruster_version,
-        git_ref=None,
-        yes=True,
-        verbose=False,
-    )
-
     base = mcmc.get_nominal_inputs(system)
 
     # Determine thruster and load data
@@ -156,7 +146,7 @@ def main(args):
     operating_conditions = list(data)
 
     # Load operating conditions into input dict
-    operating_params = ["P_b", "V_a", "mdot_a"]
+    operating_params = ["P_b", "V_a", "mdot_a", "B_hat"]
     for param in operating_params:
         long_name = hallmd.data.opcond_keys[param.casefold()]
         inputs_unnorm = np.array([getattr(cond, long_name) for cond in data.keys()])
@@ -211,6 +201,9 @@ def main(args):
             sampler = mcmc.PreviousRunSampler(
                 params_to_calibrate, data, system, base, opts, prev_run_file=args.prev, burn_fraction=0.5
             )
+        case "fixed":
+            sampler = mcmc.FixedSampler(
+                params_to_calibrate, data, system, base, opts, args.init_sample)
         case _:
             raise ValueError("Unreachable")
 

--- a/scripts/pem_mcmc/__init__.py
+++ b/scripts/pem_mcmc/__init__.py
@@ -7,13 +7,14 @@ from pem_mcmc.analysis import analyze
 from pem_mcmc.io import append_sample_row, load_system, read_output_file
 from pem_mcmc.metrics import likelihood_and_distances, log_posterior
 from pem_mcmc.options import ExecutionOptions, load_system_and_opts
-from pem_mcmc.samplers import DRAMSampler, PreviousRunSampler, PriorSampler
+from pem_mcmc.samplers import DRAMSampler, PreviousRunSampler, PriorSampler, FixedSampler
 from pem_mcmc.types import Value
 
 __all__ = [
     "DRAMSampler",
     "PreviousRunSampler",
     "PriorSampler",
+    "FixedSampler",
     "get_nominal_inputs",
     "load_system_and_opts",
     "append_sample_row",

--- a/scripts/pem_mcmc/samplers.py
+++ b/scripts/pem_mcmc/samplers.py
@@ -208,3 +208,30 @@ class DRAMSampler(Sampler):
 
     def __iter__(self):
         return iter(self.sampler)
+    
+
+class FixedSampler(Sampler):
+    """
+    'Sampler' that just draws from a fixed sample (its 'initial'). Used simply
+    as a hack to evaluate the PEM for a single set of parameters.
+    """
+    def __init__(
+            self,
+            variables,
+            data,
+            system,
+            base_vars,
+            opts,
+            init_sample_file: PathLike | None = None,
+    ):
+        super().__init__(variables, data, system, base_vars, opts, init_sample_file)
+        
+    def __next__(self):
+        # "draw" the same, initial sample
+
+        sample = self._init_sample
+        logp = self.logpdf(sample)
+        return sample, logp, np.isfinite(logp)
+    
+    def __iter__(self):
+        return self

--- a/src/hallmd/data/__init__.py
+++ b/src/hallmd/data/__init__.py
@@ -312,7 +312,7 @@ class OperatingCondition:
     :ivar discharge_voltage_v: the discharge voltage in Volts.
     :ivar anode_mass_flow_rate_kg_s: the anode mass flow rate in kg/s.
     :ivar magnetic_field_scale: a factor by which to scale magnetic field from file, optional and assumed unity if not provided.
-    """
+    """ # noqa: E501
 
     background_pressure_torr: float
     discharge_voltage_v: float
@@ -515,7 +515,7 @@ def _load_single_file(file: PathLike) -> dict[OperatingCondition, ThrusterData]:
     if mdot_a is None:
         mdot_t = table.get("total flow rate (mg/s)")
         if mdot_t is not None and (cathode_flow_fraction := table.get("cathode flow fraction")) is not None:
-            anode_flow_fraction = 1/(1+cathode_flow_fraction) #1 - cathode_flow_fraction #erroneous definition maybe built in for SPT-100/h9 results; references I've encountered the cathode flow fraction is a percentage of the anode, not total, flow
+            anode_flow_fraction = 1/(1+cathode_flow_fraction) #1 - cathode_flow_fraction #erroneous definition maybe built in for SPT-100/h9 results; references I've encountered the cathode flow fraction is a percentage of the anode, not total, flow # noqa: E501
             mdot_a = mdot_t * anode_flow_fraction
         elif mdot_t is not None and (anode_flow_ratio := table.get("anode-cathode flow ratio")) is not None:
             anode_flow_fraction = anode_flow_ratio / (anode_flow_ratio + 1)
@@ -547,10 +547,10 @@ def _load_single_file(file: PathLike) -> dict[OperatingCondition, ThrusterData]:
         I_mag = table.get('magnet current (a)') #try to read coil current
         I_star = table.get('nominal magnet current (a)') #try to read nominal coil current
         if I_mag is not None and I_star is not None: #if both are included
-            B_hat = I_mag / I_star #linearly scale B field by actual vs nominal coil current (ignores potential nonlinearity/saturation)
+            B_hat = I_mag / I_star #linearly scale B field by actual vs nominal coil current (ignores potential nonlinearity/saturation) # noqa: E501
         else: #if not provided in any way
             pass #do nothing (B_hat will remain None, which will be interpreted later)
-            #this effectively makes the magnetic field scale an optional parameter and is trying to promote backwards compatibility
+            #this effectively makes the magnetic field scale an optional parameter and is trying to promote backwards compatibility # noqa: E501
 
     num_rows = len(table[keys[0]])
     row = 0

--- a/src/hallmd/data/__init__.py
+++ b/src/hallmd/data/__init__.py
@@ -299,6 +299,7 @@ opcond_keys: dict[str, str] = {
     "p_b": "background_pressure_torr",
     "v_a": "discharge_voltage_v",
     "mdot_a": "anode_mass_flow_rate_kg_s",
+    "b_hat": "magnetic_field_scale",
 }
 """Forward mapping between operating condition short and long names."""
 
@@ -310,11 +311,13 @@ class OperatingCondition:
     :ivar background_pressure_torr: the background pressure in Torr.
     :ivar discharge_voltage_v: the discharge voltage in Volts.
     :ivar anode_mass_flow_rate_kg_s: the anode mass flow rate in kg/s.
+    :ivar magnetic_field_scale: a factor by which to scale magnetic field from file, optional and assumed unity if not provided.
     """
 
     background_pressure_torr: float
     discharge_voltage_v: float
     anode_mass_flow_rate_kg_s: float
+    magnetic_field_scale: float = 1.0 #assume field is nominal if unspecified
 
 
 # ====================================================================================================================
@@ -487,6 +490,8 @@ def _read_measurement(
         std = abs_err * scale / 2
     elif (rel_err := table.get(_rel_uncertainty_key(key))) is not None:
         std = rel_err * mean / 2
+        
+    std = np.abs(std) #hot fix for negative data that is computed relatively
 
     if end is None:
         end = val.size
@@ -510,7 +515,7 @@ def _load_single_file(file: PathLike) -> dict[OperatingCondition, ThrusterData]:
     if mdot_a is None:
         mdot_t = table.get("total flow rate (mg/s)")
         if mdot_t is not None and (cathode_flow_fraction := table.get("cathode flow fraction")) is not None:
-            anode_flow_fraction = 1 - cathode_flow_fraction
+            anode_flow_fraction = 1/(1+cathode_flow_fraction) #1 - cathode_flow_fraction #erroneous definition maybe built in for SPT-100/h9 results; references I've encountered the cathode flow fraction is a percentage of the anode, not total, flow
             mdot_a = mdot_t * anode_flow_fraction
         elif mdot_t is not None and (anode_flow_ratio := table.get("anode-cathode flow ratio")) is not None:
             anode_flow_fraction = anode_flow_ratio / (anode_flow_ratio + 1)
@@ -535,16 +540,34 @@ def _load_single_file(file: PathLike) -> dict[OperatingCondition, ThrusterData]:
             f"{file}: No discharge voltage provided."
             + " Expected a key called `discharge voltage (v)` or `anode voltage (v)`."
         )
+    
+    # Get magnetic field scale
+    B_hat = table.get("magnetic field scale") #try to read directly
+    if B_hat is None: #if there is none directly provided
+        I_mag = table.get('magnet current (a)') #try to read coil current
+        I_star = table.get('nominal magnet current (a)') #try to read nominal coil current
+        if I_mag is not None and I_star is not None: #if both are included
+            B_hat = I_mag / I_star #linearly scale B field by actual vs nominal coil current (ignores potential nonlinearity/saturation)
+        else: #if not provided in any way
+            pass #do nothing (B_hat will remain None, which will be interpreted later)
+            #this effectively makes the magnetic field scale an optional parameter and is trying to promote backwards compatibility
 
     num_rows = len(table[keys[0]])
     row = 0
     opcond_start = 0
-    opcond = OperatingCondition(P_B[0], V_a[0], mdot_a[0])
+    if B_hat is not None: #if magnetic field scaling is specified
+        opcond = OperatingCondition(P_B[0], V_a[0], mdot_a[0], B_hat[0])
+    else: #if unspecified, leave as defau
+        opcond = OperatingCondition(P_B[0], V_a[0], mdot_a[0])
+        
 
     while True:
         next_opcond = opcond
         if row < num_rows:
-            next_opcond = OperatingCondition(P_B[row], V_a[row], mdot_a[row])
+            if B_hat is not None: #if magnetic field scaling is specified
+                next_opcond = OperatingCondition(P_B[row], V_a[row], mdot_a[row], B_hat[row])
+            else: #if unspecified, leave as defau
+                next_opcond = OperatingCondition(P_B[row], V_a[row], mdot_a[row])
             if next_opcond == opcond:
                 row += 1
                 continue

--- a/src/hallmd/models/pem_to_julia.json
+++ b/src/hallmd/models/pem_to_julia.json
@@ -22,6 +22,7 @@
     "f_n": ["config", "neutral_ingestion_multiplier"],
 	"c_w": ["config", "wall_loss_model", "loss_scale"],
     "ncharge": ["config", "ncharge"],
+    "B_hat": ["config", "magnetic_field_scale"],
     "num_cells": ["simulation", "grid", "num_cells"],
     "dt": ["simulation", "dt"],
     "I_B0": ["output", "average", "ion_current"],


### PR DESCRIPTION
Added MCMCIterators as a dependency for the project.
Small update to README.

Added a sampler to the mcmc capabilities that just considers a fixed sample (i.e., delta function distribution).

Added a magnetic field scaling parameter (exposed in HallThruster.jl) as an *optional* operating condition parameter. When omitted, assumes unity.

Modified cathode flow fraction definition to be consistent with literature for the SPT-100 and the SPT-140 (and more broadly conventional).

Hot fix to solve cases where relative error calculations produce negative error (because corresponding data are negative). Note that this is still poor behavior. Really assuming relative error of any sort is ill-posed in this case. But this stops the code from failing, at least.

Fixes #

## Proposed Changes

  -
  -
  -
